### PR TITLE
Fix Empty list cause by .xci files

### DIFF
--- a/dbibackend/dbibackend.py
+++ b/dbibackend/dbibackend.py
@@ -116,7 +116,7 @@ def process_list_command(context, work_dir_path):
     for dirName, subdirList, fileList in os.walk(work_dir_path):
         log.debug(f'Found directory: {dirName}')
         for filename in fileList:
-            if filename.lower().endswith('.nsp') or filename.lower().endswith('nsz'):
+            if filename.lower().endswith('.nsp') or filename.lower().endswith('nsz') or filename.lower().endswith('.xci'):
                 log.debug(f'\t{filename}')
                 cached_titles[f'{filename}'] = str(Path(dirName).joinpath(filename))
 


### PR DESCRIPTION
DBI already supports `.xci` files, just allowing `.xci` without any other modifications. I have tested it locally and it works like chain. Fixed #6 